### PR TITLE
Add PHP PDF offer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Angebotstool
-Erstes Setup für PDF-Erstellung
+
+Dieses Repository enthält ein simples PHP-Skript zur Erstellung von Angebots-PDFs mittels [FPDF](https://www.fpdf.org/). 
+
+## Verwendung
+
+1. Rufe `index.php` in einem Browser auf. 
+2. Fülle das Formular mit dem Kundennamen sowie bis zu drei Leistungen und Preisen aus.
+3. Nach dem Absenden wird das PDF generiert und direkt als Download angeboten.
+
+Für die PDF-Erstellung wird die PHP-Erweiterung `php-fpdf` benötigt.

--- a/generate_pdf.php
+++ b/generate_pdf.php
@@ -1,0 +1,58 @@
+<?php
+// Verarbeitung des Formulars und Generierung des PDF-Angebots
+
+require_once 'fpdf.php'; // FPDF einbinden, Pfad in /usr/share/php
+
+function format_euro(float $value): string {
+    return number_format($value, 2, ',', '.') . ' \xE2\x82\xAC';
+}
+
+$customer = isset($_POST['customer']) ? trim($_POST['customer']) : '';
+$services = isset($_POST['service']) ? $_POST['service'] : [];
+
+if ($customer === '') {
+    die('Kein Kundenname angegeben.');
+}
+
+$total = 0.0;
+foreach ($services as $service) {
+    $price = isset($service['price']) ? (float)$service['price'] : 0.0;
+    $total += $price;
+}
+
+$pdf = new FPDF();
+$pdf->AddPage();
+$pdf->SetFont('Arial', 'B', 16);
+
+// Optionales Logo oben rechts
+// $pdf->Image('logo.png', 150, 10, 40);
+
+$pdf->Cell(0, 10, 'Angebot', 0, 1);
+$pdf->SetFont('Arial', '', 12);
+$pdf->Cell(0, 10, 'Datum: ' . date('d.m.Y'), 0, 1);
+$pdf->Cell(0, 10, 'Kunde: ' . htmlspecialchars($customer), 0, 1);
+$pdf->Ln(5);
+
+$pdf->SetFillColor(200, 200, 200);
+$pdf->Cell(120, 10, 'Leistung', 1, 0, 'L', true);
+$pdf->Cell(60, 10, 'Preis', 1, 1, 'R', true);
+
+foreach ($services as $service) {
+    $desc = $service['desc'] ?? '';
+    $price = isset($service['price']) ? (float)$service['price'] : 0.0;
+    if ($desc === '' && $price == 0.0) {
+        continue;
+    }
+    $pdf->Cell(120, 10, htmlspecialchars($desc), 1);
+    $pdf->Cell(60, 10, format_euro($price), 1, 1, 'R');
+}
+
+$pdf->SetFont('Arial', 'B', 12);
+$pdf->Cell(120, 10, 'Gesamt', 1);
+$pdf->Cell(60, 10, format_euro($total), 1, 1, 'R');
+
+header('Content-Type: application/pdf');
+header('Content-Disposition: attachment; filename="angebot.pdf"');
+$pdf->Output('D', 'angebot.pdf');
+exit;
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,35 @@
+<?php
+// Einfaches Angebotstool Formular
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Angebot erstellen</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        form { max-width: 600px; margin: 0 auto; }
+        label { display: block; margin-top: 10px; }
+    </style>
+</head>
+<body>
+<h1>Angebot erstellen</h1>
+<form action="generate_pdf.php" method="post">
+    <label>Kundenname
+        <input type="text" name="customer" required>
+    </label>
+    <?php for ($i = 1; $i <= 3; $i++): ?>
+    <fieldset>
+        <legend>Leistung <?php echo $i; ?></legend>
+        <label>Bezeichnung
+            <input type="text" name="service[<?php echo $i; ?>][desc]">
+        </label>
+        <label>Preis (EUR)
+            <input type="number" step="0.01" name="service[<?php echo $i; ?>][price]">
+        </label>
+    </fieldset>
+    <?php endfor; ?>
+    <button type="submit">PDF erzeugen</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add form page `index.php` for creating offers
- add `generate_pdf.php` to create a PDF using FPDF
- update README with usage instructions

## Testing
- `php -l index.php`
- `php -l generate_pdf.php`


------
https://chatgpt.com/codex/tasks/task_e_68401b499ee88331ba4f2f5a22e070c0